### PR TITLE
Add "dev" keyword to desktop file

### DIFF
--- a/com.google.ChromeDev.desktop
+++ b/com.google.ChromeDev.desktop
@@ -111,6 +111,7 @@ Terminal=false
 Icon=com.google.ChromeDev
 Type=Application
 Categories=Network;WebBrowser;
+Keywords=dev;
 MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;x-scheme-handler/http;x-scheme-handler/https;
 Actions=new-window;new-private-window;
 


### PR DESCRIPTION
It's in the icon but does not match e.g. search in GNOME Software or flathub.org for "chrome dev" because "chromedev" is a single token throughout the file.