### PR TITLE
update to runtime 23.08

### DIFF
--- a/com.google.ChromeDev.yaml
+++ b/com.google.ChromeDev.yaml
@@ -1,9 +1,9 @@
 app-id: com.google.ChromeDev
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 command: chrome
 separate-locales: false
 build-options:
@@ -119,6 +119,7 @@ modules:
       # For extra-data to be able to extract the .deb
       - install -Dm 755 /{usr,app}/bin/ar
       - cp /usr/lib/$(gcc --print-multiarch)/libbfd-*.so /app/lib
+      - cp -a /usr/lib/$(gcc --print-multiarch)/libsframe.so* ${FLATPAK_DEST}/lib
     sources:
       - type: extra-data
         # From https://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages

--- a/com.google.ChromeDev.yaml
+++ b/com.google.ChromeDev.yaml
@@ -119,7 +119,7 @@ modules:
       # For extra-data to be able to extract the .deb
       - install -Dm 755 /{usr,app}/bin/ar
       - cp /usr/lib/$(gcc --print-multiarch)/libbfd-*.so /app/lib
-      - cp -a /usr/lib/$(gcc --print-multiarch)/libsframe.so* ${FLATPAK_DEST}/lib
+      - cp -a /usr/lib/$(gcc --print-multiarch)/libsframe.so* /app/lib
     sources:
       - type: extra-data
         # From https://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages


### PR DESCRIPTION
@refi64 Please consider updating the runtime to latest 23.08. While still maintained 22.08 had its first release 7 months ago. 

Should also close this [issue](https://github.com/flathub/com.google.ChromeDev/issues/101)