### PR TITLE
bump Platform and base app to 24.08

### DIFF
--- a/com.google.ChromeDev.yaml
+++ b/com.google.ChromeDev.yaml
@@ -1,9 +1,9 @@
 app-id: com.google.ChromeDev
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 command: chrome
 separate-locales: false
 build-options:


### PR DESCRIPTION
bump org.freedesktop.Sdk to 24.08, com.google.Chrome already using this https://github.com/flathub/com.google.Chrome/pull/335